### PR TITLE
feat: 完了タスクの自動削除機能を追加

### DIFF
--- a/client/src/components/task-preview.tsx
+++ b/client/src/components/task-preview.tsx
@@ -109,6 +109,13 @@ export function TaskPreview({ content, onMarkdownUpdate }: TaskPreviewProps) {
         checkedAt: Date.now(),
       });
     }
+
+    // Auto-delete completed task from markdown after a short delay
+    if (checked) {
+      setTimeout(() => {
+        removeTaskFromMarkdown(taskText);
+      }, 1000); // 1 second delay to show completion state briefly
+    }
   };
 
   const updateMarkdownContent = (taskText: string, checked: boolean) => {
@@ -122,6 +129,20 @@ export function TaskPreview({ content, onMarkdownUpdate }: TaskPreviewProps) {
         return `${indent}[${checkbox}]${spacing}${taskText}`;
       }
       return line;
+    });
+    
+    onMarkdownUpdate(updatedLines.join('\n'));
+  };
+
+  const removeTaskFromMarkdown = (taskText: string) => {
+    const lines = content.split('\n');
+    const updatedLines = lines.filter(line => {
+      const taskMatch = line.match(/^(\s*-\s*)\[([x\s])\](\s*)(.+)$/);
+      // Remove line if it matches the completed task
+      if (taskMatch && taskMatch[4].trim() === taskText) {
+        return false;
+      }
+      return true;
     });
     
     onMarkdownUpdate(updatedLines.join('\n'));


### PR DESCRIPTION
## Summary
• 完了したタスクをMarkdownから自動的に削除する機能を追加
• 完了状態を1秒間表示後、自動削除を実行
• UIの整理とユーザビリティの向上

## Test plan
- [ ] タスクを完了状態にしてチェックボックスをクリック
- [ ] 1秒後にタスクがMarkdownから削除されることを確認
- [ ] 複数のタスクでも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)